### PR TITLE
fixed certificate renewal cronjob

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -93,7 +93,7 @@ fi
 if [ -z "${NO_CERT_REFRESH+x}" ]; then
   echo "Enabling certificate renewal checks every day"
   cron
-  echo "`shuf -i 0-59 -n 1` `shuf -i 1-5 -n 1` * * * /usr/src/renew-cert.sh" > /root/renew-cert
+  echo "`shuf -i 0-59 -n 1` `shuf -i 1-5 -n 1` * * * root /usr/src/renew-cert.sh" > /root/renew-cert
   cp /root/renew-cert /etc/cron.d/renew-cert
   chmod 0644 /etc/cron.d/renew-cert
 fi


### PR DESCRIPTION
The file format in /etc/cron.d is slightly different from the usual cron format, as it requires an additional column with the user that should execute the command.